### PR TITLE
Make returns immutable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ class DrupalAttribute extends Map {
    * @returns {DrupalAttribute}
    */
   addClass(args) {
-    let self = this;
+    let instance = new DrupalAttribute(this);
     let values = [];
 
     for (let i = 0; i < arguments.length; i++) {
@@ -20,11 +20,11 @@ class DrupalAttribute extends Map {
         value = [value];
       }
 
-      if (!self.has('class')) {
-        self.setAttribute('class', []);
+      if (!instance.has('class')) {
+        instance.set('class', []);
       }
 
-      let classes = self.get('class');
+      let classes = instance.get('class');
 
       value.forEach(function (d) {
         if (classes.indexOf(d) < 0) {
@@ -33,13 +33,14 @@ class DrupalAttribute extends Map {
       });
     });
 
-    return this;
+    return instance;
   }
 
   removeClass(value) {
+    let instance = new DrupalAttribute(this);
     let classes = [];
 
-    if (this.has('class')) {
+    if (instance.has('class')) {
       classes = this.get('class');
     }
 
@@ -55,7 +56,7 @@ class DrupalAttribute extends Map {
       }
     });
 
-    return this;
+    return instance;
   }
 
   hasClass(value) {
@@ -69,15 +70,17 @@ class DrupalAttribute extends Map {
   }
 
   setAttribute(key, value) {
-    this.set(key, value);
+    let instance = new DrupalAttribute(this);
+    instance.set(key, value);
 
-    return this;
+    return instance;
   }
 
   removeAttribute(key) {
-    this.delete(key);
+    let instance = new DrupalAttribute(this);
+    instance.delete(key);
 
-    return this;
+    return instance;
   }
 
   toString() {

--- a/test/add-class.js
+++ b/test/add-class.js
@@ -7,14 +7,15 @@ tap.test('addClass', function(test) {
   test.test('should support method chaining', function(test) {
     let attribute = new DrupalAttribute();
 
-    test.equal(attribute.addClass('foo'), attribute);
+    attribute = attribute.addClass('foo');
+    test.equal(true, DrupalAttribute.prototype.isPrototypeOf(attribute));
     test.end();
   });
 
   test.test('should support being passed a string', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .addClass('foo')
       .addClass('bar')
     ;
@@ -26,7 +27,7 @@ tap.test('addClass', function(test) {
   test.test('should support being passed an array', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute.addClass(['foo', 'bar']);
+    attribute = attribute.addClass(['foo', 'bar']);
 
     test.same(attribute.get('class'), ['foo', 'bar']);
     test.end();
@@ -35,7 +36,7 @@ tap.test('addClass', function(test) {
   test.test('should support adding an existing class', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .addClass('foo')
       .addClass('foo')
     ;
@@ -47,7 +48,7 @@ tap.test('addClass', function(test) {
   test.test('should accept being passed multiple parameters', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .addClass('foo', 'bar', ['foo-bar'])
     ;
 

--- a/test/has-class.js
+++ b/test/has-class.js
@@ -7,7 +7,7 @@ tap.test('hasClass', function(test) {
   test.test('should support being passed a string', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute.addClass('foo');
+    attribute = attribute.addClass('foo');
 
     test.ok(attribute.hasClass('foo'));
     test.end();

--- a/test/remove-attribute.js
+++ b/test/remove-attribute.js
@@ -7,14 +7,15 @@ tap.test('removeAttribute', function(test) {
   test.test('should support method chaining', function(test) {
     let attribute = new DrupalAttribute();
 
-    test.equal(attribute.removeAttribute('foo'), attribute);
+    attribute = attribute.removeAttribute('foo');
+    test.equal(true, DrupalAttribute.prototype.isPrototypeOf(attribute));
     test.end();
   });
 
   test.test('should support being passed a string', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .setAttribute('foo', 'bar')
       .removeAttribute('foo')
     ;

--- a/test/remove-class.js
+++ b/test/remove-class.js
@@ -7,14 +7,15 @@ tap.test('removeClass', function(test) {
   test.test('should support method chaining', function(test) {
     let attribute = new DrupalAttribute();
 
-    test.equal(attribute.removeClass('foo'), attribute);
+    attribute = attribute.removeClass('foo');
+    test.equal(true, DrupalAttribute.prototype.isPrototypeOf(attribute));
     test.end();
   });
 
   test.test('should support being passed a string', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .addClass('foo')
       .addClass('bar')
       .removeClass('bar')
@@ -27,7 +28,7 @@ tap.test('removeClass', function(test) {
   test.test('should support being passed an array', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .addClass(['foo', 'bar', 'foo-bar'])
       .removeClass(['foo', 'foo-bar'])
     ;
@@ -39,7 +40,7 @@ tap.test('removeClass', function(test) {
   test.test('should support being called on an instance with no class set', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute
+    attribute = attribute
       .removeClass(['bar'])
     ;
 

--- a/test/set-attribute.js
+++ b/test/set-attribute.js
@@ -7,14 +7,15 @@ tap.test('setAttribute', function(test) {
   test.test('should support method chaining', function(test) {
     let attribute = new DrupalAttribute();
 
-    test.equal(attribute.setAttribute('foo', 'bar'), attribute);
+    attribute = attribute.setAttribute('foo', 'bar');
+    test.equal(true, DrupalAttribute.prototype.isPrototypeOf(attribute));
     test.end();
   });
 
   test.test('should support being passed a key and a value', function (test) {
     let attribute = new DrupalAttribute();
 
-    attribute.setAttribute('foo', 'bar');
+    attribute = attribute.setAttribute('foo', 'bar');
 
     test.equal(attribute.get('foo'), 'bar');
     test.end();

--- a/test/to-string.js
+++ b/test/to-string.js
@@ -14,7 +14,7 @@ tap.test('toString', function(test) {
   test.test('should return a valid HTML attribute string when at least one attribute has been set', function (test) {
     let attribute = new DrupalAttributes();
 
-    attribute
+    attribute = attribute
       .setAttribute('foo', 'bar')
       .setAttribute('bar', 'foo')
       .setAttribute('foo-bar', ['foo', 'bar'])


### PR DESCRIPTION
We've integrated this into kss-node so that we can use drupal attributes in our styleguide twig files, but we're seeing attributes bleed into lower templates.

Making the method calls immutable and returning new instances should resolve this.

